### PR TITLE
Add driver info functions

### DIFF
--- a/api/liboni/drivers/riffa/onidriver_riffa.c
+++ b/api/liboni/drivers/riffa/onidriver_riffa.c
@@ -15,6 +15,9 @@
 
 #define MIN(a,b) ((a<b) ? a : b)
 
+const oni_driver_info_t driverInfo
+    = {.name = "riffa", .major = 1, .minor = 0, .patch = 0, .preRelase = NULL};
+
 struct oni_riffa_ctx_impl {
     oni_size_t block_size;
     fpga_t* fpga;
@@ -254,9 +257,9 @@ int oni_driver_get_opt(oni_driver_ctx driver_ctx,
     return ONI_EINVALOPT;
 }
 
-const char* oni_driver_str()
+const oni_driver_info_t* oni_driver_info()
 {
-    return "riffa";
+    return &driverInfo;
 }
 
 static inline oni_conf_off_t _oni_register_offset(oni_config_t reg)

--- a/api/liboni/drivers/riffa/onidriver_riffa.c
+++ b/api/liboni/drivers/riffa/onidriver_riffa.c
@@ -16,7 +16,7 @@
 #define MIN(a,b) ((a<b) ? a : b)
 
 const oni_driver_info_t driverInfo
-    = {.name = "riffa", .major = 1, .minor = 0, .patch = 0, .preRelase = NULL};
+    = {.name = "riffa", .major = 1, .minor = 0, .patch = 0, .pre_relase = NULL};
 
 struct oni_riffa_ctx_impl {
     oni_size_t block_size;

--- a/api/liboni/oni.c
+++ b/api/liboni/oni.c
@@ -787,6 +787,11 @@ void oni_version(int *major, int *minor, int *patch)
     *patch = ONI_VERSION_PATCH;
 }
 
+const oni_driver_info_t* oni_get_driver_info(const oni_ctx ctx) 
+{
+    return ctx->driver.info();
+}
+
 const char *oni_error_str(int err)
 {
     assert(err > ONI_MINERRORNUM && "Invalid error number.");

--- a/api/liboni/oni.h
+++ b/api/liboni/oni.h
@@ -78,6 +78,7 @@ ONI_EXPORT void oni_destroy_frame(oni_frame_t *frame);
 
 // Helpers
 ONI_EXPORT void oni_version(int *major, int *minor, int *patch);
+ONI_EXPORT const oni_driver_info_t* oni_get_driver_info(const oni_ctx ctx);
 ONI_EXPORT const char *oni_error_str(int err);
 
 #ifdef __cplusplus

--- a/api/liboni/onidefs.h
+++ b/api/liboni/onidefs.h
@@ -91,4 +91,12 @@ typedef uint64_t oni_fifo_time_t; // FIFO bound timers use 64-bit words; // TODO
 // Register size
 #define ONI_REGSZ sizeof(oni_reg_val_t)
 
+typedef struct {
+    const char *name;
+    const int major;
+    const int minor;
+    const int patch;
+    const char *preRelase;
+} oni_driver_info_t;
+
 #endif

--- a/api/liboni/onidefs.h
+++ b/api/liboni/onidefs.h
@@ -96,7 +96,7 @@ typedef struct {
     const int major;
     const int minor;
     const int patch;
-    const char *preRelase;
+    const char *pre_relase;
 } oni_driver_info_t;
 
 #endif

--- a/api/liboni/onidriver.h
+++ b/api/liboni/onidriver.h
@@ -49,7 +49,7 @@ ONI_DRIVER_EXPORT int oni_driver_set_opt(oni_driver_ctx driver_ctx, int driver_o
 ONI_DRIVER_EXPORT int oni_driver_get_opt(oni_driver_ctx driver_ctx, int driver_option, void *value, size_t* option_len);
 
 // Get a string identifying the driver
-ONI_DRIVER_EXPORT const char *oni_driver_str();
+ONI_DRIVER_EXPORT const oni_driver_info_t *oni_driver_info();
 
 #endif
 

--- a/api/liboni/onidriverloader.c
+++ b/api/liboni/onidriverloader.c
@@ -75,7 +75,7 @@ int oni_create_driver(const char* lib_name, oni_driver_t* driver)
     LOAD_FUNCTION(set_opt_callback);
     LOAD_FUNCTION(set_opt);
     LOAD_FUNCTION(get_opt);
-    LOAD_FUNCTION(str);
+    LOAD_FUNCTION(info);
 
     if (!rc) {
         driver->ctx = driver->create_ctx();

--- a/api/liboni/onidriverloader.h
+++ b/api/liboni/onidriverloader.h
@@ -29,7 +29,7 @@ typedef int(*oni_driver_set_opt_f)(oni_driver_ctx, int, const void *, size_t);
 typedef int(*oni_driver_get_opt_f)(oni_driver_ctx, int, void *, size_t *);
 typedef int(*oni_driver_set_opt_callback_f)(oni_driver_ctx, int, const void *, size_t);
 
-typedef const char*(*oni_driver_str_f)();
+typedef const oni_driver_info_t*(*oni_driver_info_f)();
 
 // Driver field with function table and driver context
 typedef struct oni_driver {
@@ -45,7 +45,7 @@ typedef struct oni_driver {
     oni_driver_set_opt_callback_f set_opt_callback;
     oni_driver_set_opt_f set_opt;
     oni_driver_get_opt_f get_opt;
-    oni_driver_str_f str;
+    oni_driver_info_f info;
 } oni_driver_t;
 
 int oni_create_driver(const char *lib_name, oni_driver_t *driver);


### PR DESCRIPTION
Simple implementation of a driver info structure that can inform of curent loaded driver as well as its version.
It is just a const struct in the onidriver with name and semantic versioning, a simple method to return a pointer to it in the onidriver and a wrapper function in the high-level API.

If this seems ok, I will merge ir, merge the ft600 branch and add this same driver info to that onidriver