### PR TITLE
Add the ability to refresh the device table without closing the context

### DIFF
--- a/api/clroni/clroni/Context.cs
+++ b/api/clroni/clroni/Context.cs
@@ -67,7 +67,7 @@ namespace oni
         /// maps a fully-qualified <see cref="Device.Address"/> to a
         /// <see cref="Device"/> instance.
         /// </summary>
-        public readonly Dictionary<uint, Device> DeviceTable;
+        public Dictionary<uint, Device> DeviceTable { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="Context"/> with the
@@ -103,7 +103,13 @@ namespace oni
             MaxReadFrameSize = (uint)GetIntOption((int)Option.MAXREADFRAMESIZE);
             MaxWriteFrameSize = (uint)GetIntOption((int)Option.MAXWRITEFRAMESIZE);
 
-            // Populate device table
+            PopulateDeviceTable();
+            
+        }
+
+        // Populate device table
+        private void PopulateDeviceTable()
+        {
             int num_devs = GetIntOption((int)Option.NUMDEVICES);
             DeviceTable = new Dictionary<uint, Device>(num_devs);
             int size_dev = Marshal.SizeOf(new Device());
@@ -117,6 +123,15 @@ namespace oni
                 DeviceTable.Add(d.Address, d);
                 table = new IntPtr((long)table + size_dev);
             }
+        }
+
+        /// <summary>
+        /// Issues a reset command to the hardware and refreshes the device table.
+        /// </summary>
+        public void Refresh()
+        {
+            SetIntOption((int)Option.RESET, 1);
+            PopulateDeviceTable();
         }
 
         // GetOption


### PR DESCRIPTION
For clroni. This is useful for cases when a device has settings that affect its block size and a full disposal of the context after changing said setting, which is only effective after a reset, is undesired. Thus, allows for creating a context, setting the relevant parameters, refreshing the table and continue work.

Mainly, this PR adds a new `oni.Context.Refresh()` method to issue a reset and reload the device table, moves the device table query to its own private function that can be calles from both  `Refresh()` and the constructor and changes  `DeviceTable` from a readonly member to a private set property so functionality remains the same.