### PR TITLE
Expose unmanaged pointer to frame data payload

### DIFF
--- a/api/clroni/clroni-test/Host.cs
+++ b/api/clroni/clroni-test/Host.cs
@@ -41,7 +41,7 @@ namespace clroni_test
                     {
                         if (display)
                         {
-                            var dat = frame.Data<ushort>();
+                            var dat = frame.GetData<ushort>();
                             var idx = frame.DeviceAddress;
                             Console.WriteLine("\t[{0}] Dev: {1} ({2})", frame.Clock, idx, ctx.DeviceTable[idx].Description);
                             Console.WriteLine("\t[{0}]", String.Join(", ", dat));

--- a/api/clroni/clroni/Frame.cs
+++ b/api/clroni/clroni/Frame.cs
@@ -45,10 +45,12 @@ namespace oni
         }
 
         /// <summary>
-        /// Retrieve a managed copy of the <see cref="Frame"/> data.
+        /// Retrieves a managed copy of the <see cref="Frame"/> data.
         /// </summary>
-        /// <returns>Array containing the <see cref="Frame"/> data.</returns>
-        public T[] Data<T>() where T : unmanaged
+        /// <returns>
+        /// A managed array containing a copy of the <see cref="Frame"/> data.
+        /// </returns>
+        public T[] GetData<T>() where T : unmanaged
         {
             var frame = (frame_t*)handle.ToPointer();
             var output = new T[frame->data_sz / sizeof(T)];
@@ -68,7 +70,7 @@ namespace oni
         }
 
         /// <summary>
-        /// Retrieve the host acquisition clock counter value at frame creation.
+        /// The host acquisition clock counter value at frame creation.
         /// See <see cref="Context.AcquisitionClockHz"/> and
         /// <see cref="Context.ResetFrameClock"/>.
         /// </summary>
@@ -81,8 +83,13 @@ namespace oni
         public uint DeviceAddress => ((frame_t*)handle.ToPointer())->dev_idx;
 
         /// <summary>
-        /// Get the payload data size in bytes. See <see cref="Frame.Data{T}"/>.
+        /// The payload data size in bytes.
         /// </summary>
         public uint DataSize => ((frame_t*)handle.ToPointer())->data_sz;
+
+        /// <summary>
+        /// A pointer to the payload data.
+        /// </summary>
+        public IntPtr Data => (IntPtr)((frame_t*)handle.ToPointer())->data;
     }
 }

--- a/api/clroni/clroni/clroni.csproj
+++ b/api/clroni/clroni/clroni.csproj
@@ -6,7 +6,7 @@
     <PackageTags>ONI Open Ephys ONIX</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>5.0.1</Version>
+    <Version>6.0.0</Version>
     <Authors>Jon Newman</Authors>
     <Company>Open Ephys</Company>
     <Copyright>Copyright © Jonathan Newman</Copyright>
@@ -15,8 +15,6 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <Platforms>AnyCPU;x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/open-ephys/liboni</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR allows direct access to the raw data payload field in the `Frame` class. This will allow optimizations where data might be copied out without requiring allocation of managed arrays. The generic `Data` method was also renamed to make it easier to recognize that it is producing a copy of the data rather than providing a view into the payload buffer.