### PR TITLE
Increase Number of Test Devices

### DIFF
--- a/api/liboni/drivers/test/queue_u8.h
+++ b/api/liboni/drivers/test/queue_u8.h
@@ -8,7 +8,9 @@
 
 typedef struct {
     size_t capacity;
-    uint8_t front, rear, size;
+    size_t front;
+    size_t rear;
+    size_t size;
     uint8_t *array;
 } queue_u8_t;
 


### PR DESCRIPTION
In the test driver, automatically populate with four test devices per hub. 
Bug fix - changed queue_u8_t member types from uint8_t to size_t to prevent overflow conditions with large streams.