### PR TITLE
Remove mention of maximum device/hub numbers

### DIFF
--- a/api/liboni/oni.h
+++ b/api/liboni/oni.h
@@ -5,7 +5,7 @@
 // NB: see https://semver.org/
 #define ONI_VERSION_MAJOR 4
 #define ONI_VERSION_MINOR 3
-#define ONI_VERSION_PATCH 10
+#define ONI_VERSION_PATCH 11
 
 #define ONI_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))

--- a/api/liboni/onix.h
+++ b/api/liboni/onix.h
@@ -11,12 +11,8 @@ extern "C" {
 #define ONI_EXPORT
 #endif
 
-// Device definitions
-#define MAXDEVID 99999
-
-// NB: "Officially" supported device IDs for the ONIX project occupy
-// device IDs < MAXDEVID. IDs above this value are not reserved and can be used
-// for custom projects without future conflict.
+// NB:  Device IDs are 32-bit integers with the following format:
+//     Reserved(8-bit).Company(8-bit).Device(16-bit) 
 // NB: If you add a device here, make sure to update oni_device_str().
 enum {
     ONIX_NULL               = 0,    // Placeholder device
@@ -51,15 +47,7 @@ enum {
     ONIX_HARPSYNCINPUT      = 30,   // Harp synchronization data input device
     ONIX_RHS2116            = 31,   // Intan RHS2116 bioamplifier and stimulator
     ONIX_RHS2116TRIGGER     = 32,   // Multi Intan RHS2116 stimulation trigger
-
-    // NB: Final reserved device ID. Always on bottom
-    ONIX_MAXDEVICEID        = MAXDEVID,
-
-    // >= MAXDEVID: Not reserved. Free to use for custom projects
 };
-
-// Hub definitions
-#define MAXHUBID 99999
 
 // Each hub has a "hidden" information device with a fixed device index and 
 // several read only registers
@@ -74,9 +62,8 @@ enum {
     ONIX_HUB_DELAYNS        = 5,    // Hub to host transmission delay in nanoseconds
 };
 
-// NB: "Officially" supported hub IDs for the ONIX project occupy
-// hub IDs < MAXHUBID. IDs above this value are not reserved and can be used
-// for custom projects without future conflict.
+// NB: Hub IDs are 32-bit integers that uniquely identify the hub. They have the folowing format:
+//     Reserved(8-bit).Company(8-bit).Hub(16-bit)
 // NB: If you add a hub here, make sure to update oni_hub_str().
 enum {
     ONIX_HUB_NULL           = 0,    // Placeholder hub
@@ -85,11 +72,6 @@ enum {
     ONIX_HUB_HSNP           = 3,    // Open Ephys headstage-neuropix1
     ONIX_HUB_HSRHS2116      = 4,    // Open Ephys headstage-rhs2116
     ONIX_HUB_HS64S          = 5,    // Open Ephys headstage-64s
-
-    // NB: Final reserved hub ID. Always on bottom
-    ONIX_HUB_MAXID          = MAXHUBID,
-
-    // >= MAXHUBID: Not reserved. Free to use for custom projects
 };
 
 // ONIX Specific configuration registers


### PR DESCRIPTION
Updated onix.h to be in-line with current ONI specifications, where maximum device/hub IDs are replaced by formatting IDs using the following format:  Reserved(8-bit).Company(8-bit).Device(16-bit) .