### PR TITLE
Fix Windows driver library loading issue when using custom search path

### DIFF
--- a/api/liboni/onidriverloader.c
+++ b/api/liboni/onidriverloader.c
@@ -17,7 +17,7 @@ static inline void close_library(lib_handle_t handle) {
 static inline lib_handle_t open_library(const char* name)
 {
 #ifdef _WIN32
-    return LoadLibrary(name);
+    return LoadLibraryEx(name, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 #else
     // Clear errors
     dlerror();


### PR DESCRIPTION
The host application’s custom DLL search paths prevent `onidriverloader` from locating the relevant hardware translation driver library, causing dynamic loading to fail. For instance, the Open Ephys GUI uses custom paths for plugin dependencies. Although @aacuevas addressed this in the GUI with `SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)` (see [PR 629](https://github.com/open-ephys/plugin-GUI/pull/629)), this solution caused issues with plugins like [NI-DAQmx](https://github.com/open-ephys-plugins/nidaq-plugin), as the NI-DAQ library couldn't find and load dependencies in custom paths, returning erroneous data. Removing `SetDefaultDllDirectories` fixed the NI-DAQ plugin.

This PR updates `onidriverloader` to use `LoadLibraryEx` with `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`, enabling the oni driver loader to search both default and custom DLL paths set by the host application.