### PR TITLE
Fix macOS build errors

### DIFF
--- a/api/liboni/drivers/ft600/onidriver_ft600.c
+++ b/api/liboni/drivers/ft600/onidriver_ft600.c
@@ -281,7 +281,7 @@ inline void oni_ft600_reset_ctx(oni_ft600_ctx ctx)
 	oni_ft600_restart_acq(ctx);
 }
 
-inline void oni_ft600_reset_acq(oni_ft600_ctx ctx, int hard)
+static inline void oni_ft600_reset_acq(oni_ft600_ctx ctx, int hard)
 {
 	if (hard) {
 		FT_WriteGPIO(ctx->ftHandle, 0x01, 0x01);
@@ -316,7 +316,7 @@ inline void oni_ft600_stop_acq(oni_ft600_ctx ctx)
 	oni_ft600_restart_acq(ctx);
 }
 
-inline int oni_ft600_sendcmd(oni_ft600_ctx ctx, uint8_t* buffer, size_t size)
+static inline int oni_ft600_sendcmd(oni_ft600_ctx ctx, uint8_t* buffer, size_t size)
 {
 	ULONG transferred = 0;
 	ULONG total = 0;
@@ -337,7 +337,7 @@ inline int oni_ft600_sendcmd(oni_ft600_ctx ctx, uint8_t* buffer, size_t size)
 	return ONI_ESUCCESS;
 }
 
-oni_driver_ctx oni_driver_create_ctx()
+oni_driver_ctx oni_driver_create_ctx(void)
 {
 	oni_ft600_ctx ctx;
 	ctx = calloc(1, sizeof(struct oni_ft600_ctx_impl));
@@ -885,7 +885,7 @@ int oni_driver_get_opt(oni_driver_ctx driver_ctx,
 	return ONI_EINVALOPT;
 }
 
-const oni_driver_info_t* oni_driver_info() 
+const oni_driver_info_t* oni_driver_info(void) 
 {
     return &driverInfo;
 }

--- a/api/liboni/onidriver.h
+++ b/api/liboni/onidriver.h
@@ -28,7 +28,7 @@ typedef void *oni_driver_ctx;
 #define ONI_DRIVER_EXPORT
 #endif
 
-ONI_DRIVER_EXPORT oni_driver_ctx oni_driver_create_ctx();
+ONI_DRIVER_EXPORT oni_driver_ctx oni_driver_create_ctx(void);
 ONI_DRIVER_EXPORT int oni_driver_destroy_ctx(oni_driver_ctx);
 
 // Initialize driver. Argument is the host device index
@@ -49,7 +49,7 @@ ONI_DRIVER_EXPORT int oni_driver_set_opt(oni_driver_ctx driver_ctx, int driver_o
 ONI_DRIVER_EXPORT int oni_driver_get_opt(oni_driver_ctx driver_ctx, int driver_option, void *value, size_t* option_len);
 
 // Get a string identifying the driver
-ONI_DRIVER_EXPORT const oni_driver_info_t *oni_driver_info();
+ONI_DRIVER_EXPORT const oni_driver_info_t *oni_driver_info(void);
 
 #endif
 

--- a/api/liboni/onidriverloader.h
+++ b/api/liboni/onidriverloader.h
@@ -15,7 +15,7 @@ typedef void *lib_handle_t;
 #endif
 
 // Function pointers for common access
-typedef oni_driver_ctx(*oni_driver_create_ctx_f)();
+typedef oni_driver_ctx(*oni_driver_create_ctx_f)(void);
 typedef int(*oni_driver_init_f)(oni_driver_ctx, int);
 typedef int(*oni_driver_destroy_ctx_f)(oni_driver_ctx);
 
@@ -29,7 +29,7 @@ typedef int(*oni_driver_set_opt_f)(oni_driver_ctx, int, const void *, size_t);
 typedef int(*oni_driver_get_opt_f)(oni_driver_ctx, int, void *, size_t *);
 typedef int(*oni_driver_set_opt_callback_f)(oni_driver_ctx, int, const void *, size_t);
 
-typedef const oni_driver_info_t*(*oni_driver_info_f)();
+typedef const oni_driver_info_t*(*oni_driver_info_f)(void);
 
 // Driver field with function table and driver context
 typedef struct oni_driver {


### PR DESCRIPTION
Enhance function declarations and definitions by incorporating the `void` parameter to explicitly indicate that these functions don’t accept any arguments. Additionally, modify the linkage of certain functions to `static inline` to address build errors encountered when compiling with macOS compilers.