### PR TITLE
Extend usability of oni-repl

### DIFF
--- a/api/liboni/oni-repl/main.c
+++ b/api/liboni/oni-repl/main.c
@@ -706,8 +706,14 @@ reset:
         printf("\ti - set a filter to display frames only from a particular device\n");
         printf("\tt - print current device table\n");
         printf("\tp - toggle running/pause register\n");
-        printf("\tr[m|i[x]] - read from device register. [m] for managed registers. [i] for i2c raw registers, [ix] for i2c 16-bit addresses\n");
-        printf("\tw[m|i[x]] - write to device register. [m] for managed registers. [i] for i2c raw registers, [ix] for i2c 16-bit addresses\n");
+        printf("\tr[m|i[x]] - read from device register.\n");
+        printf("\t [m]: managed registers.\n");
+        printf("\t [i]: i2c raw registers.\n");
+        printf("\t [ix]: 16-bit i2c raw registers.\n");
+        printf("\tw[m|i[x]] - write to device register.\n");
+        printf("\t [m]: managed registers.\n");
+        printf("\t [i]: i2c raw registers.\n");
+        printf("\t [ix]: 16-bit i2c raw registers.\n");
         printf("\th - get hub information about a device\n");
         printf("\tH - print all hubs in the current configuration\n");
         printf("\ta - reset the acquisition clock counter\n");

--- a/api/liboni/oni-repl/main.c
+++ b/api/liboni/oni-repl/main.c
@@ -390,6 +390,21 @@ void print_hub_info(size_t hub_idx)
     rc ? printf("%s\n", oni_error_str(rc)) : printf("%u\n", hub_delay_ns);
 }
 
+void update_dev_table() 
+{
+    // Examine device table
+    size_t num_devs_sz = sizeof(num_devs);
+    oni_get_opt(ctx, ONI_OPT_NUMDEVICES, &num_devs, &num_devs_sz);
+
+    // Get the device table
+    size_t devices_sz = sizeof(oni_device_t) * num_devs;
+    devices = (oni_device_t *)realloc(devices, devices_sz);
+    if (devices == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    oni_get_opt(ctx, ONI_OPT_DEVICETABLE, devices, &devices_sz);
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -539,14 +554,7 @@ exit:
     //rc = oni_set_opt(ctx, ONI_OPT_RESET, &val, sizeof(val));
 
     // Examine device table
-    size_t num_devs_sz = sizeof(num_devs);
-    oni_get_opt(ctx, ONI_OPT_NUMDEVICES, &num_devs, &num_devs_sz);
-
-    // Get the device table
-    size_t devices_sz = sizeof(oni_device_t) * num_devs;
-    devices = (oni_device_t *)realloc(devices, devices_sz);
-    if (devices == NULL) { exit(EXIT_FAILURE); }
-    oni_get_opt(ctx, ONI_OPT_DEVICETABLE, devices, &devices_sz);
+    update_dev_table();
 
     // Dump files, if required
     if (dump) {
@@ -715,6 +723,7 @@ exit:
             oni_size_t reset = 1;
             rc = oni_set_opt(ctx, ONI_OPT_RESET, &reset, sizeof(reset));
             if (rc) { printf("Error: %s\n", oni_error_str(rc)); }
+            update_dev_table();
         }
         else if (c == 'd') {
             display = (display == 0) ? 1 : 0;

--- a/api/liboni/oni.c
+++ b/api/liboni/oni.c
@@ -1304,7 +1304,7 @@ static int _oni_alloc_write_buffer(oni_ctx ctx, void **data, size_t size)
     return ONI_ESUCCESS;
 }
 
-// NB: Allow context to relase control of buffer without refilling in the case
+// NB: Allow context to release control of buffer without refilling in the case
 // of restart
 static void _oni_dump_buffers(oni_ctx ctx)
 {


### PR DESCRIPTION
- Reloads the device table when issuing a reset command
- Fixes #31 
- Adds register access mode for managed and i2c-raw registers, to ease usability when testing devices featuring those
- Fixes #32 
