### PR TITLE
Add `$ORIGIN` to rpath for Linux in liboni Makefile

### DIFF
--- a/api/liboni/Makefile
+++ b/api/liboni/Makefile
@@ -15,7 +15,7 @@ PREFIX    :=  /usr/local
 ifeq ($(UNAME), Linux)
 DNAME     :=  $(NAME).so.1
 DNAMELN   :=  $(NAME).so
-LDFLAGS   :=  -L. -ldl
+LDFLAGS   :=  -L. -ldl -Wl,-rpath,'$$ORIGIN'
 endif
 ifeq ($(UNAME), Darwin)
 DNAME     :=  $(NAME).dylib


### PR DESCRIPTION
This pull request modifies the liboni Makefile to include the `-Wl,-rpath,'$$ORIGIN'` option in the linker flags. This ensures the runtime linker can find shared libraries relative to `liboni.so`. This is crucial when the liboni and driver libraries are not present in any of the `LD_LIBRARY_PATH` paths. Consequently, liboni fails to load the driver libraries during runtime.

This issue can be reproduced in the Open Ephys GUI when loading `libonidriver_ft600.so` fails to initialize an ONI Acquisition Board via the [Acquisition Board](https://github.com/open-ephys-plugins/acquisition-board) plugin. Adding `$ORIGIN` to the rpath resolves this issue.