### PR TITLE
Upgrade clroni to .net8.0

### DIFF
--- a/api/clroni/clroni-repl/Repl.cs
+++ b/api/clroni/clroni-repl/Repl.cs
@@ -1,29 +1,19 @@
 ﻿using oni;
-using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 using CommandLine;
-using System.Linq;
 using CommandLine.Text;
 
 namespace ClrOniRepl
 {
-    class DataProcessor
+    class DataProcessor(Context context, bool display = false, ulong displayEvery = 1000)
     {
-        private readonly Context context;
+        private readonly Context context = context;
 
         public volatile bool Quit = false;
 
-        public bool Display { get; set; }
+        public bool Display { get; set; } = display;
 
-        public ulong DisplayEvery { get; set; }
-
-        public DataProcessor(Context context, bool display = false, ulong displayEvery = 1000)
-        {
-            this.context = context;
-            Display = display;
-            DisplayEvery = displayEvery;
-        }
+        public ulong DisplayEvery { get; set; } = displayEvery;
 
         public void CaptureData()
         {
@@ -219,7 +209,12 @@ namespace ClrOniRepl
                                         break;
 
                                     case 'x':
+                                        processor.Quit = true;
+                                        procThread.Join(200);
                                         ctx.Refresh();
+                                        Console.Write(Helpers.DeviceTableString(ctx));
+                                        ctx.Start(true);
+                                        procThread.Start();
                                         break;
 
                                     default:

--- a/api/clroni/clroni-repl/clroni-repl.csproj
+++ b/api/clroni/clroni-repl/clroni-repl.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Title>ONI RELLPL (RCRLLR)(CLR)</Title>
+    <Title>ONI REPL</Title>
     <Description>Test application for clroni.</Description>
     <PackageTags>ONI Open Ephys</PackageTags>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.2.2</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © Open Ephys, Inc.</Copyright>

--- a/api/clroni/clroni/Context.cs
+++ b/api/clroni/clroni/Context.cs
@@ -2,8 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Security.Permissions;
-using System.Text;
 
 namespace oni
 {
@@ -183,17 +181,20 @@ namespace oni
         // String GetOption
         private string GetStringOption(int option, bool drv_opt = false)
         {
+            const int BufferSize = 1000;
+
             var sz = Marshal.AllocHGlobal(IntPtr.Size);
             if (IntPtr.Size == 4)
             {
-                Marshal.WriteInt32(sz, 1000);
+                Marshal.WriteInt32(sz, BufferSize);
             }
             else
             {
-                Marshal.WriteInt64(sz, 1000);
+                Marshal.WriteInt64(sz, BufferSize);
             }
 
-            var str = new StringBuilder(1000);
+            //var str = new StringBuilder(1000);
+            var str = new char[BufferSize];
 
             int rc;
             if (!drv_opt)
@@ -555,7 +556,6 @@ namespace oni
         /// by IDisposable.
         /// </summary>
         /// <param name="disposing"></param>
-        [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
         protected virtual void Dispose(bool disposing)
         {
 

--- a/api/clroni/clroni/ContextHandle.cs
+++ b/api/clroni/clroni/ContextHandle.cs
@@ -1,16 +1,11 @@
 ﻿using Microsoft.Win32.SafeHandles;
-using System.Runtime.ConstrainedExecution;
-using System.Security.Permissions;
 
 namespace oni
 {
-    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode = true)]
-    [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
-    internal unsafe class ContextHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal class ContextHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal ContextHandle() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return NativeMethods.oni_destroy_ctx(handle) == 0;

--- a/api/clroni/clroni/Frame.cs
+++ b/api/clroni/clroni/Frame.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
-using System.Security.Permissions;
 
 namespace oni
 {
@@ -10,8 +8,6 @@ namespace oni
     /// Managed wrapper for an ONI-compliant data frame implementation. Produced by calls
     /// to <see cref="Context.ReadFrame"/> .
     /// </summary>
-    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode = true)]
-    [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
     public unsafe class Frame : SafeHandleZeroOrMinusOneIsInvalid
     {
 
@@ -36,7 +32,6 @@ namespace oni
         /// </summary>
         /// <returns>True if the handle is released successfully (always the case
         /// in this implementation)</returns>
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         protected override bool ReleaseHandle()
         {
             GC.RemoveMemoryPressure(((frame_t*)handle.ToPointer())->data_sz);

--- a/api/clroni/clroni/ONIException.cs
+++ b/api/clroni/clroni/ONIException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 
 namespace oni
 {
@@ -15,10 +14,13 @@ namespace oni
         /// </summary>
         public readonly int Number;
 
+        /// <summary>
+        /// Initializes a new <see cref="ONIException"/>
+        /// </summary>
         protected ONIException() { }
 
         /// <summary>
-        /// Initializes a new <see cref="oni.ONIException"/>
+        /// Initializes a new <see cref="ONIException"/>
         /// </summary>
         /// <param name="errnum">The error code returned by the native ONI API.</param>
         internal ONIException(int errnum)
@@ -31,9 +33,5 @@ namespace oni
         /// </summary>
         public override string Message =>
             Marshal.PtrToStringAnsi(NativeMethods.oni_error_str(Number));
-
-        protected ONIException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        { }
     }
 }

--- a/api/clroni/clroni/clroni.csproj
+++ b/api/clroni/clroni/clroni.csproj
@@ -1,16 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>CLR bindings for liboni</Title>
     <Description>CLR bindings to liboni, an ONI compliant API for data acquisition.</Description>
     <PackageTags>ONI Open Ephys ONIX</PackageTags>
-    <TargetFramework>net472</TargetFramework>
-    <UseWindowsForms>true</UseWindowsForms>
-<<<<<<< riffa-hardreset
-    <Version>6.2.0</Version>
-=======
-    <Version>6.1.3</Version>
->>>>>>> main
+    <TargetFramework>net8.0</TargetFramework>
+    <UseWindowsForms>false</UseWindowsForms>
+    <Version>6.3.0-dev1</Version>
     <Authors>Jon Newman</Authors>
     <Company>Open Ephys, Inc.</Company>
     <Copyright>©Open Ephys, Inc.</Copyright>

--- a/api/clroni/clroni/oni.cs
+++ b/api/clroni/clroni/oni.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Runtime.ConstrainedExecution;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
 
 namespace oni
 {
@@ -20,11 +19,8 @@ namespace oni
         /// </summary>
         public static readonly Version LibraryVersion;
 
-        private const CallingConvention CCCdecl = CallingConvention.Cdecl;
+        const string LibraryName = "liboni";
 
-        private const string LibraryName = "liboni";
-
-        // The static constructor prepares static readonly fields
         static NativeMethods()
         {
             // Set once LibraryVersion to version()
@@ -47,60 +43,69 @@ namespace oni
                         requiredVersion));
         }
 
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial void oni_version(out int major, out int minor, out int patch);
 
-
-
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern void oni_version(out int major, out int minor, out int patch);
-
-        [DllImport(LibraryName, CallingConvention = CCCdecl, CharSet = CharSet.Ansi)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ContextHandle oni_create_ctx(string driver_name);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_init_ctx(ContextHandle ctx, int host_idx);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_init_ctx(ContextHandle ctx, int host_idx);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-        internal static extern int oni_destroy_ctx(IntPtr ctx);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_destroy_ctx(IntPtr ctx);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_get_opt(ContextHandle ctx, int option, IntPtr val, IntPtr size);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_get_opt(ContextHandle ctx, int option, IntPtr val, IntPtr size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_get_opt(ContextHandle ctx, int option, StringBuilder val, IntPtr size);
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int oni_get_opt(ContextHandle ctx, int option, [Out] char[] val, IntPtr size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_set_opt(ContextHandle ctx, int option, IntPtr val, int size);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_set_opt(ContextHandle ctx, int option, IntPtr val, int size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_set_opt(ContextHandle ctx, int option, string val, int size);
+        [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_set_opt(ContextHandle ctx, int option, string val, int size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern IntPtr oni_get_driver_info(ContextHandle ctx);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial IntPtr oni_get_driver_info(ContextHandle ctx);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_get_driver_opt(ContextHandle ctx, int option, IntPtr val, IntPtr size);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_get_driver_opt(ContextHandle ctx, int option, IntPtr val, IntPtr size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_get_driver_opt(ContextHandle ctx, int option, StringBuilder val, IntPtr size);
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int oni_get_driver_opt(ContextHandle ctx, int option, [Out] char[] val, IntPtr size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_set_driver_opt(ContextHandle ctx, int option, IntPtr val, int size);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_set_driver_opt(ContextHandle ctx, int option, IntPtr val, int size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_set_driver_opt(ContextHandle ctx, int option, string val, int size);
+        [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_set_driver_opt(ContextHandle ctx, int option, string val, int size);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_read_reg(ContextHandle ctx, uint dev_idx, uint addr, IntPtr val);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_read_reg(ContextHandle ctx, uint dev_idx, uint addr, IntPtr val);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern int oni_write_reg(ContextHandle ctx, uint dev_idx, uint addr, uint val);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_write_reg(ContextHandle ctx, uint dev_idx, uint addr, uint val);
 
         //[DllImport(LibraryName, CallingConvention = CCCdecl, SetLastError = true)]
         //internal static extern int oni_read_frame(ContextHandle ctx, out Frame frame);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl, SetLastError = true)]
-        internal static extern int oni_read_frame(ContextHandle ctx, out IntPtr frame);
+        [LibraryImport(LibraryName, SetLastError = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_read_frame(ContextHandle ctx, out IntPtr frame);
 
         //[DllImport(LibraryName, CallingConvention = CCCdecl, SetLastError = true)]
         //internal static extern int oni_create_frame(ContextHandle ctx, out Frame frame, uint dev_idx, IntPtr data, uint data_sz);
@@ -108,17 +113,20 @@ namespace oni
         //[DllImport(LibraryName, CallingConvention = CCCdecl, SetLastError = true)]
         //internal static extern int oni_write_frame(ContextHandle ctx, Frame frame);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl, SetLastError = true)]
-        internal static extern int oni_create_frame(ContextHandle ctx, out IntPtr frame, uint dev_idx, IntPtr data, uint data_sz);
+        [LibraryImport(LibraryName, SetLastError = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_create_frame(ContextHandle ctx, out IntPtr frame, uint dev_idx, IntPtr data, uint data_sz);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl, SetLastError = true)]
-        internal static extern int oni_write_frame(ContextHandle ctx, IntPtr frame);
+        [LibraryImport(LibraryName, SetLastError = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial int oni_write_frame(ContextHandle ctx, IntPtr frame);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        internal static extern void oni_destroy_frame(IntPtr frame);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial void oni_destroy_frame(IntPtr frame);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern IntPtr oni_error_str(int err);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial IntPtr oni_error_str(int err);
     }
 }

--- a/api/clroni/clroni/onix.cs
+++ b/api/clroni/clroni/onix.cs
@@ -106,10 +106,12 @@ namespace oni
     [SuppressUnmanagedCodeSecurity] // NB: Call into native code without incurring the performance loss of a run-time security check when doing so
     public static partial class NativeMethods
     {
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern IntPtr onix_device_str(int id);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        internal static partial IntPtr onix_device_str(int id);
 
-        [DllImport(LibraryName, CallingConvention = CCCdecl)]
-        internal static extern IntPtr onix_hub_str(int id);
+        [LibraryImport(LibraryName)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        internal static partial IntPtr onix_hub_str(int id);
     }
 }


### PR DESCRIPTION
- Take advantage of the API improvements afforded by this framework
- Follow best practices for P/Invoke: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices
- DllImport -> LibraryImport
- Use [In] and [Out] attributes on array parameters and dont use StringBuilder
- Fixes #25 
- However, cannot be used in e.g. OpenEphys.Onix1 until the whole stack gets upgraded to .net8.0 