### PR TITLE
Remove windows desktop dependency for clroni

### DIFF
--- a/api/clroni/clroni-repl/clroni-repl.csproj
+++ b/api/clroni/clroni-repl/clroni-repl.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Title>ONI RELLPL (RCRLLR)(CLR)</Title>
+    <Title>ONI REPL</Title>
     <Description>Test application for clroni.</Description>
     <PackageTags>ONI Open Ephys</PackageTags>
     <TargetFramework>net472</TargetFramework>

--- a/api/clroni/clroni/clroni.csproj
+++ b/api/clroni/clroni/clroni.csproj
@@ -1,12 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>CLR bindings for liboni</Title>
     <Description>CLR bindings to liboni, an ONI compliant API for data acquisition.</Description>
     <PackageTags>ONI Open Ephys ONIX</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <UseWindowsForms>true</UseWindowsForms>
-    <Version>6.2.0</Version>
+    <Version>6.3.0</Version>
     <Authors>Jon Newman</Authors>
     <Company>Open Ephys, Inc.</Company>
     <Copyright>©Open Ephys, Inc.</Copyright>


### PR DESCRIPTION
- Remove windows forms dependency as well
- Partially addresses #25 but does not perform full cross platform API upgrade