### PR TITLE
Additional cleanup in `oni_destroy_ctx`

### DIFF
--- a/api/liboni/oni.c
+++ b/api/liboni/oni.c
@@ -177,6 +177,17 @@ int oni_destroy_ctx(oni_ctx ctx)
     int rc = ctx->driver.destroy_ctx(ctx->driver.ctx);
     if (rc) return rc;
 
+    // Release shared read buffer
+    if (ctx->shared_rbuf != NULL)
+        _ref_dec(&(ctx->shared_rbuf->count));
+
+    // Release shared write buffer
+    if (ctx->shared_wbuf != NULL)
+        _ref_dec(&(ctx->shared_wbuf->count));
+
+    if (ctx->dev_table != NULL)
+        free(ctx->dev_table);
+
     if (ctx->dev_hash_table != NULL)
         free(ctx->dev_hash_table);
 

--- a/api/liboni/oni.c
+++ b/api/liboni/oni.c
@@ -177,11 +177,12 @@ int oni_destroy_ctx(oni_ctx ctx)
     int rc = ctx->driver.destroy_ctx(ctx->driver.ctx);
     if (rc) return rc;
 
-    // Release shared read buffer
+    // NB: _ref_dec is only called when a new shared buffer is created. We must
+    // therefore explicitly decrement the active shared buffers here to balance
+    // the initial _ref_inc from their creation.
     if (ctx->shared_rbuf != NULL)
         _ref_dec(&(ctx->shared_rbuf->count));
 
-    // Release shared write buffer
     if (ctx->shared_wbuf != NULL)
         _ref_dec(&(ctx->shared_wbuf->count));
 

--- a/api/liboni/oni.h
+++ b/api/liboni/oni.h
@@ -5,7 +5,7 @@
 // NB: see https://semver.org/
 #define ONI_VERSION_MAJOR 4
 #define ONI_VERSION_MINOR 5
-#define ONI_VERSION_PATCH 0
+#define ONI_VERSION_PATCH 1
 
 #define ONI_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))


### PR DESCRIPTION
I needed to add these additional lines to avoid memory leaks on Windows with the acquisition board plugin. Let me know if this makes sense to merge in `main`.