### PR TITLE
Make oni_frame_t use void* for data

### DIFF
--- a/api/liboni/oni.c
+++ b/api/liboni/oni.c
@@ -688,7 +688,7 @@ int oni_read_frame(const oni_ctx ctx, oni_frame_t **frame)
     total_size += rsize;
 
     // Direct frame data's view into the pre-collected buffer
-    assert(ctx->shared_rbuf->read_pos + rsize <= ctx->shared_rbuf->end_pos 
+    assert(ctx->shared_rbuf->read_pos + rsize <= ctx->shared_rbuf->end_pos
         && "Attempted to read past buffer end");
     iframe->private.f.data = ctx->shared_rbuf->read_pos;
     ctx->shared_rbuf->read_pos += rsize;
@@ -1225,7 +1225,7 @@ static inline int _oni_read_config(oni_ctx ctx, oni_config_t reg, oni_reg_val_t 
 
 static int _oni_ensure_read_buffer(oni_ctx ctx)
 {
-    // NB: This function can only be called if the device table has been 
+    // NB: This function can only be called if the device table has been
     // populated and contains devices that produce data.
     if (ctx->max_read_frame_size == 0)
         return ONI_EINVALARG;

--- a/api/liboni/oni.h
+++ b/api/liboni/oni.h
@@ -51,7 +51,7 @@ typedef struct {
     const oni_fifo_time_t time;     // Frame time (ACQCLKHZ)
     const oni_fifo_dat_t dev_idx;   // Device index that produced or accepts the frame
     const oni_fifo_dat_t data_sz;   // Size in bytes of data buffer
-    char *data;                     // Raw data block
+    void *data;                     // Raw data block
 
 } oni_frame_t;
 


### PR DESCRIPTION
Hi!

Just a small follow-up to the previous patch: `ctx->shared_rbuf->read_pos` is `uint8_t`, while `iframe->private.f.data` is `char`. The latter can have any signedness, the C compiler decides, but often it's signed, so we get this warning.

This patch just silences the warning with no functional change. I looked into using `uint8_t` everywhere for data, since that is the more modern way to do things in C (distinguishes from printable characters, has a defined width and signedness on every compiler, etc), but that would be a larger, API-breaking change, so I went with the most minimal change instead.

This cast should be fine on most compilers, but it is a bit iffy because `char` will most likely range from `[-128, 127]`, and uint8_t is `0 - 255`. So we do rely on the compiler to not do crazy things, and for us to not interpret the value. All compilers I know will work just fine here and wrap around, but technically the result would be undefined.

If needed, I can split the whitespace changes into their own commit.
Cheers,
    Matthias
