### PR TITLE
Fix crash by opening driver libraries with RTLD_NODELETE

### DIFF
--- a/api/liboni/onidriverloader.c
+++ b/api/liboni/onidriverloader.c
@@ -21,7 +21,14 @@ static inline lib_handle_t open_library(const char* name)
 #else
     // Clear errors
     dlerror();
-    lib_handle_t lib = dlopen(name, RTLD_NOW | RTLD_LOCAL);
+    // RTLD_NODELETE: never unmap the driver on dlclose(). Some drivers (notably
+    // the FT600 driver, which statically links libftd3xx/libusb) spawn internal
+    // background threads - e.g. libusb's netlink hotplug monitor - that are not
+    // joined by oni_driver_destroy_ctx(). Unmapping the library while such a
+    // thread is still alive leaves it executing freed code and crashes the host
+    // process. Keeping the mapping resident also means a subsequent dlopen reuses
+    // the already-initialized driver state instead of spawning a duplicate thread.
+    lib_handle_t lib = dlopen(name, RTLD_NOW | RTLD_LOCAL | RTLD_NODELETE);
 #ifndef NDEBUG
     char *e = dlerror();
     if (e != NULL)


### PR DESCRIPTION
Hi!

I was investigating a nasty crash in Syntalos and traced it back to an issue in liboni: When the driver library is unloaded, a bunch of threads from the FT600 library, notably libusb threads, stick around and don't quit. This is expected behavior - and annoyingly, that static library embeds libusb (all something to be solved on another day).

Then, if *any* USB event comes in and wakes up the background thread from the unloaded library, it tries to execute code that is gone missing and jumps into uninitialized memory (or to a random spot).

So, unloading this is inherently unsafe. Therefore, I changed the `dlopen()` call to use `RTLD_NODELETE` which will prevent the symbols from going missing. Repeated calls to `dlopen()` will just recycle the already loaded symbols, so this is safe, and when the program terminates, everything should be unloaded cleanly.

The only alternative to this that I see would be making *absolutely sure* that all background threads of the driver have joined, but due to how libusb works (and who knows what else a driver may run), we can't do that. It would also be kinda brittle to rely on this.

Let me know if this solution makes sense to you!
Best,
    Matthias
